### PR TITLE
Add force_delete capability to Kafka resources

### DIFF
--- a/kafka/resource_kafka_topic.go
+++ b/kafka/resource_kafka_topic.go
@@ -54,7 +54,7 @@ func kafkaTopicResource() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Forces resource deletion even if errors occur during deletion.",
-			},
+			}, // This parameter allows removing the resource from state when the Kafka cluster is unavailable
 		},
 	}
 }


### PR DESCRIPTION
This PR adds the ability to force delete Kafka resources when the Kafka cluster is no longer available. This is useful for ephemeral environments where the Kafka cluster is deleted before the actual resources (topics, ACLs, etc.) are deleted. In such cases, we get connection errors and need to alter the state manually to delete the resources. With this change, we can set force_delete=true on the resources and they will be removed from the state even when the Kafka cluster is unavailable.